### PR TITLE
Gestion missions

### DIFF
--- a/src/main/java/dev/controller/ManagerController.java
+++ b/src/main/java/dev/controller/ManagerController.java
@@ -2,7 +2,7 @@ package dev.controller;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -131,9 +131,9 @@ public class ManagerController {
 	 * @throws RestClientException
 	 * @throws URISyntaxException
 	 */
-	@GetMapping("/departements/missions")
+	@PostMapping("/departements/missions")
 	@Secured("ROLE_MANAGER")
-	public ResponseEntity<List<DemandeAbsenceValidationDTO>> recupToutesLesMission(HttpServletRequest request, SelectionAbsence selection) throws RestClientException, URISyntaxException {
+	public ResponseEntity<RapportAbsences> recupToutesLesMission(HttpServletRequest request, @RequestBody SelectionAbsence selection) throws RestClientException, URISyntaxException {
 		
 		String get = "https://missions-back.cleverapps.io/mission/";
 
@@ -145,19 +145,22 @@ public class ManagerController {
 		// On transforme la liste des missions récupérées en demandes et on les
 		// injecte dans la liste des demandes
 		
-		List<DemandeAbsenceValidationDTO> missions = new ArrayList<>();
+		RapportAbsences rapport = new RapportAbsences();
+		LocalDate debutMois =  LocalDate.of(selection.getAnnee(), selection.getMois(), 1);
+		LocalDate finMois = LocalDate.of(selection.getAnnee(), selection.getMois(), debutMois.lengthOfMonth());
+		
 		
 		if (respHttp2.getStatusCodeValue() == 200 && respHttp2.getBody() != null) {
-			Arrays.asList(respHttp2.getBody()).stream().map(mission -> new DemandeAbsenceDTO(mission))
+			List<DemandeAbsenceValidationDTO> missions = Arrays.asList(respHttp2.getBody()).stream().map(mission -> new DemandeAbsenceDTO(mission))
 					.filter(demande -> service.verifColExist(selection.getDepartement(), demande))
 					.filter(demande -> demande.getStatus().equals(Status.VALIDEE))
-					.filter(demande -> demande.getDateDebut().getYear() == selection.getAnnee())
-					.filter(demande -> demande.getDateDebut().getMonth().getValue() == selection.getMois())
+					.filter(demande -> demande.getDateDebut().getYear() == selection.getAnnee() || demande.getDateFin().getYear() == selection.getAnnee())
 					.map(demande -> service.transformerDemande(demande))
-					.collect(Collectors.toList()).forEach(demande -> missions.add(demande));
+					.collect(Collectors.toList());
+			rapport = service.creerRapportMission(missions, selection);
 		}
 		
-		return ResponseEntity.status(HttpStatus.OK).body(missions);
+		return ResponseEntity.status(HttpStatus.OK).body(rapport);
 	}
 
 }

--- a/src/main/java/dev/controller/ManagerController.java
+++ b/src/main/java/dev/controller/ManagerController.java
@@ -131,9 +131,9 @@ public class ManagerController {
 	 * @throws RestClientException
 	 * @throws URISyntaxException
 	 */
-	@GetMapping("/departement/{id}/missions")
+	@GetMapping("/departements/missions")
 	@Secured("ROLE_MANAGER")
-	public ResponseEntity<List<DemandeAbsenceValidationDTO>> recupToutesLesMission(HttpServletRequest request, @PathVariable Long id) throws RestClientException, URISyntaxException {
+	public ResponseEntity<List<DemandeAbsenceValidationDTO>> recupToutesLesMission(HttpServletRequest request, SelectionAbsence selection) throws RestClientException, URISyntaxException {
 		
 		String get = "https://missions-back.cleverapps.io/mission/";
 
@@ -149,8 +149,9 @@ public class ManagerController {
 		
 		if (respHttp2.getStatusCodeValue() == 200 && respHttp2.getBody() != null) {
 			Arrays.asList(respHttp2.getBody()).stream().map(mission -> new DemandeAbsenceDTO(mission))
-					.filter(demande -> service.recupListEmailDep(id, demande))
+					.filter(demande -> service.recupListEmailDep(selection.getDepartement(), demande))
 					.filter(demande -> demande.getStatus().equals(Status.VALIDEE))
+					.filter(demande -> demande.getDateDebut().getMonth().getValue() == selection.getMois())
 					.map(demande -> service.transformerDemande(demande))
 					.collect(Collectors.toList()).forEach(demande -> missions.add(demande));
 		}

--- a/src/main/java/dev/controller/ManagerController.java
+++ b/src/main/java/dev/controller/ManagerController.java
@@ -149,8 +149,9 @@ public class ManagerController {
 		
 		if (respHttp2.getStatusCodeValue() == 200 && respHttp2.getBody() != null) {
 			Arrays.asList(respHttp2.getBody()).stream().map(mission -> new DemandeAbsenceDTO(mission))
-					.filter(demande -> service.recupListEmailDep(selection.getDepartement(), demande))
+					.filter(demande -> service.verifColExist(selection.getDepartement(), demande))
 					.filter(demande -> demande.getStatus().equals(Status.VALIDEE))
+					.filter(demande -> demande.getDateDebut().getYear() == selection.getAnnee())
 					.filter(demande -> demande.getDateDebut().getMonth().getValue() == selection.getMois())
 					.map(demande -> service.transformerDemande(demande))
 					.collect(Collectors.toList()).forEach(demande -> missions.add(demande));

--- a/src/main/java/dev/controller/vm/Absences.java
+++ b/src/main/java/dev/controller/vm/Absences.java
@@ -31,6 +31,13 @@ public class Absences {
 		this.joursCSS = joursCSS;
 
 	}
+	
+	public Absences(String nomCollegue, String prenomCollegue, List<Integer> joursMISSIONS) {
+		this.nomCollegue = nomCollegue;
+		this.prenomCollegue = prenomCollegue;
+		this.joursMISSIONS = joursMISSIONS;
+
+	}
 
 
 

--- a/src/main/java/dev/controller/vm/RapportAbsences.java
+++ b/src/main/java/dev/controller/vm/RapportAbsences.java
@@ -17,7 +17,9 @@ public class RapportAbsences {
 	private List<Absences> listeAbsences;
 
 	public RapportAbsences() {
-
+		/**
+		 * Constructeur par défaut
+		 */
 	}
 
 	public RapportAbsences(List<Integer> joursWeekEnd, List<Absences> listeAbsences) {

--- a/src/main/java/dev/services/ManagerService.java
+++ b/src/main/java/dev/services/ManagerService.java
@@ -253,7 +253,14 @@ public class ManagerService {
 		return new RapportAbsences(weekEnd, listeAbsences);
 	}
 	
-	public boolean recupListEmailDep(long id, DemandeAbsenceDTO demande) {
+	/**
+	 * Vérifie si un collègue existe dans la base de données et dans un département précis
+	 * 
+	 * @param id
+	 * @param demande
+	 * @return boolean
+	 */
+	public boolean verifColExist(long id, DemandeAbsenceDTO demande) {
 		
 		boolean exist = false;
 		
@@ -266,6 +273,12 @@ public class ManagerService {
 		return exist;
 	}
 	
+	/**
+	 * Transforme une demande d'absence DTO en DemandeAbsenceValidationDTO
+	 * 
+	 * @param demande
+	 * @return DemandeAbsenceValidationDTO
+	 */
 	public DemandeAbsenceValidationDTO transformerDemande(DemandeAbsenceDTO demande) {
 		Collegue collegue = colRepo.findByEmail(demande.getEmail()).orElseThrow(() -> new CollegueNonTrouveException("Aucun collègue ayant cet email n'a été trouvé"));
 		return new DemandeAbsenceValidationDTO(demande, collegue.getNom(), collegue.getPrenom());


### PR DESCRIPTION
Voici la dernière version du service pour récupérer les missions. Elles sont renvoyées au front sous la forme d'un rapport d'absences contenant les jours d'absences et les jours de weekend de la période concernée.

Pour appeler le service il faut envoyer une requête post à cette url:
/manager/departements/missions

La requête prend en paramètre le même objet que pour la recherche par département/mois/année